### PR TITLE
Bump dependencies for security reasons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.1'
+ruby '>2.4.1'
 
 gem 'sinatra'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,14 @@ GEM
   specs:
     dotenv (2.4.0)
     json (2.1.0)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     rack (2.0.5)
-    rack-protection (2.0.1)
+    rack-protection (2.0.4)
       rack
-    sinatra (2.0.1)
+    sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.4)
       tilt (~> 2.0)
     tilt (2.0.8)
 
@@ -23,7 +23,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.5


### PR DESCRIPTION
I'm seeing a security advisory on Sinatra, bumped versions and also made the Ruby version a bit more tolerant.